### PR TITLE
Feature/python311 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.csv
 *.pyc
 *egg-info*
+build/*

--- a/install/client_bootstrap.sh
+++ b/install/client_bootstrap.sh
@@ -51,7 +51,7 @@ su - pi << EOF
 python3 -m venv ~/.venv
 source ~/.venv/bin/activate
 pip install -U pip setuptools wheel
-pip install RPi.GPIO mysql-connector-python
+pip install RPi.GPIO==0.7.*
 cd ${HERE}/..
 pip install .
 EOF

--- a/install/client_bootstrap.sh
+++ b/install/client_bootstrap.sh
@@ -47,12 +47,16 @@ chown -R pi: /etc/weatherstation
 mkdir -p /var/log/weatherstation
 chown -R pi: /var/log/weatherstation
 
-pip3 install Adafruit_Python_DHT mysql-connector-python
+su - pi << EOF
+python3 -m venv ~/.venv
+source ~/.venv/bin/activate
+pip install -U pip setuptools wheel
+pip install Adafruit_Python_DHT mysql-connector-python
+cd ${HERE}/..
+pip install .
+EOF
 
-cp "$HERE"/weatherstation_temperature.service /etc/systemd/system/weatherstation_temperature.service
-
-cd "$HERE"/..
-pip3 install .
+cp ${HERE}/weatherstation_temperature.service /etc/systemd/system/weatherstation_temperature.service
 
 systemctl enable weatherstation_temperature.service
 systemctl start weatherstation_temperature.service

--- a/install/client_bootstrap.sh
+++ b/install/client_bootstrap.sh
@@ -51,7 +51,7 @@ su - pi << EOF
 python3 -m venv ~/.venv
 source ~/.venv/bin/activate
 pip install -U pip setuptools wheel
-pip install Adafruit_Python_DHT mysql-connector-python
+pip install RPi.GPIO mysql-connector-python
 cd ${HERE}/..
 pip install .
 EOF

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 setup(
     name="weather-station",
@@ -19,7 +19,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Natural Language :: English",
         "Operating System :: Unix",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.6",
 )

--- a/weather_station/main.py
+++ b/weather_station/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from weather_station.sensing import temperature_humidity
 from weather_station.server import server
 from weather_station.utils.cli import parse_cli

--- a/weather_station/main.py
+++ b/weather_station/main.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from weather_station.sensing import temperature_humidity
-from weather_station.server import server
 from weather_station.utils.cli import parse_cli
 
 
@@ -9,9 +7,11 @@ def main():
     args = parse_cli()
 
     if args.listen:
+        from weather_station.server import server
         server.listen()
 
     if args.temperature:
+        from weather_station.sensing import temperature_humidity
         temperature_humidity.record()
 
 

--- a/weather_station/sensing/gpio.py
+++ b/weather_station/sensing/gpio.py
@@ -1,0 +1,197 @@
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Literal
+
+import RPi.GPIO as GPIO
+
+INVALID_RESULT: float = -1.0
+READ_RETRIES: int = 10
+
+
+class SensorError(Enum):
+    NO_ERROR = 0
+    MISSING_DATA = 1
+    CHECKSUM = 2
+    NOT_FOUND = 3
+
+
+@dataclass
+class SensorResult:
+    error: SensorError
+    temperature: float = INVALID_RESULT
+    humidity: float = INVALID_RESULT
+
+    @property
+    def is_valid(self):
+        return all(
+            [
+                self.temperature != INVALID_RESULT,
+                self.humidity != INVALID_RESULT,
+            ]
+        )
+
+    @property
+    def ok(self):
+        return self.error == SensorError.NO_ERROR
+
+
+class SensorState(Enum):
+    INIT_PULL_DOWN = 0
+    INIT_PULL_UP = 1
+    DATA_FIRST_PULL_DOWN = 2
+    DATA_PULL_UP = 3
+    DATA_PULL_DOWN = 4
+
+
+class DHT22:
+    def __init__(self, pin: int) -> None:
+        GPIO.setmode(GPIO.BCM)
+        self.pin = pin
+
+    def read_retry(self, retries: int = READ_RETRIES) -> SensorResult:
+        for _ in range(retries):
+            result = self._read()
+            if result.ok:
+                break
+        return result
+
+    def _read(self) -> SensorResult:
+        GPIO.setup(self.pin, GPIO.OUT)
+
+        # send initial high and pull down to low
+        self._send_and_sleep(GPIO.HIGH, 0.05)
+        self._send_and_sleep(GPIO.LOW, 0.02)
+
+        # change to input using pull up
+        GPIO.setup(self.pin, GPIO.IN, GPIO.PUD_UP)
+
+        data = self._collect_input()
+
+        pull_up_lengths = self._parse_pull_up_lengths(data)
+
+        if len(pull_up_lengths) == 0:
+            return SensorResult(SensorError.NOT_FOUND)
+
+        if len(pull_up_lengths) != 40:
+            return SensorResult(SensorError.MISSING_DATA)
+
+        bits = self._calculate_bits(pull_up_lengths)
+
+        bytes_ = self._bits_to_bytes(bits)
+
+        if bytes_[4] != self.checksum(bytes_):
+            return SensorResult(SensorError.CHECKSUM)
+
+        return SensorResult(
+            SensorError.NO_ERROR,
+            self._calculate_temperature(bytes_),
+            self._calculate_humidity(bytes_),
+        )
+
+    def _send_and_sleep(self, sig: Literal[0, 1], sleep: float) -> None:
+        GPIO.output(self.pin, sig)
+        time.sleep(sleep)
+
+    def _collect_input(self) -> List[bool]:
+        cnt = 0
+        cnt_limit = 100
+        last = -1
+        data = []
+
+        # loop until input does not change for 'limit' times
+        while True:
+            cur = GPIO.input(self.pin)
+            data.append(cur)
+            if last != cur:
+                cnt = 0
+                last = cur
+            else:
+                cnt += 1
+                if cnt > cnt_limit:
+                    break
+
+        return data
+
+    def _parse_pull_up_lengths(self, data: List[bool]) -> List[int]:
+        state = SensorState.INIT_PULL_DOWN
+        lengths = []
+        cur_length = 0
+
+        for idx in range(len(data)):
+            cur = data[idx]
+            cur_length += 1
+
+            match state:
+                case SensorState.INIT_PULL_DOWN:
+                    if cur == GPIO.LOW:
+                        state = SensorState.INIT_PULL_UP
+
+                case SensorState.INIT_PULL_UP:
+                    if cur == GPIO.HIGH:
+                        state = SensorState.DATA_FIRST_PULL_DOWN
+
+                case SensorState.DATA_FIRST_PULL_DOWN:
+                    if cur == GPIO.LOW:
+                        state = SensorState.DATA_PULL_UP
+
+                case SensorState.DATA_PULL_UP:
+                    # the length of this pull up will determine if it is 0 or 1
+                    if cur == GPIO.HIGH:
+                        cur_length = 0
+                        state = SensorState.DATA_PULL_DOWN
+
+                case SensorState.DATA_PULL_DOWN:
+                    if cur == GPIO.LOW:
+                        # pulled down, store the length of the previous pull
+                        # up period
+                        lengths.append(cur_length)
+                        state = SensorState.DATA_PULL_UP
+
+        return lengths
+
+    def _calculate_bits(self, pull_up_lengths: List[int]) -> List[int]:
+        # find shortest and longest periods
+        shortest = 1000
+        longest = 0
+
+        for idx in range(len(pull_up_lengths)):
+            length = pull_up_lengths[idx]
+            shortest = min(shortest, length)
+            longest = max(longest, length)
+
+        # use the halfway to determine whether the priod is long or short
+        half = shortest + (longest - shortest) / 2
+        bits = []
+
+        for idx in range(len(pull_up_lengths)):
+            bits.append(int(pull_up_lengths[idx] > half))
+
+        return bits
+
+    def _bits_to_bytes(self, bits: List[int]) -> List[int]:
+        bytes_ = []
+        byte = 0
+
+        for idx in range(len(bits)):
+            byte <<= 1
+            byte |= bits[idx]
+            if (idx + 1) % 8 == 0:
+                bytes_.append(byte)
+                byte = 0
+
+        return bytes_
+
+    def checksum(self, bytes_) -> int:
+        return bytes_[0] + bytes_[1] + bytes_[2] + bytes_[3] & 255
+
+    def _calculate_temperature(self, bytes_) -> float:
+        temp = float(((bytes_[2] & 0x7F) << 8) + bytes_[3]) / 10
+        if temp > 125:
+            return bytes_[2]
+        if bytes_[2] & 0x80:
+            return -temp
+        return temp
+
+    def _calculate_humidity(self, bytes_) -> float:
+        return ((bytes_[0] << 8) + bytes_[1]) / 10

--- a/weather_station/sensing/temperature_humidity.py
+++ b/weather_station/sensing/temperature_humidity.py
@@ -30,9 +30,6 @@ def write_csv(file_name, data, column_names):
 def record():
     config = get_config()
     sensor = DHT22(int(config["temperature"]["gpio_port"]))
-    timestamp = datetime.now().strftime(
-        config["recording"]["timestamp_format"]
-    )
 
     metadata = {
         "device_id": config["device"]["device_id"],
@@ -42,6 +39,9 @@ def record():
 
     while True:
         result = sensor.read_retry()
+        timestamp = datetime.now().strftime(
+            config["recording"]["timestamp_format"]
+        )
         if result.ok:
             data = [
                 {

--- a/weather_station/sensing/temperature_humidity.py
+++ b/weather_station/sensing/temperature_humidity.py
@@ -1,11 +1,11 @@
 import csv
 import os
+import time
 
 from datetime import datetime
-from time import sleep
 
-import Adafruit_DHT as dht
 
+from weather_station.sensing.gpio import DHT22
 from weather_station.server.client import send_data
 from weather_station.settings import APP_DIR
 from weather_station.utils.config import get_config
@@ -27,54 +27,52 @@ def write_csv(file_name, data, column_names):
         writer.writerow(data)
 
 
-def measure_temp_humid(sensor_gpio_port, timestamp_format):
-    humid, temp = dht.read_retry(dht.DHT22, sensor_gpio_port)
-    timestamp = datetime.now().strftime(timestamp_format)
-    data = [
-        {
-            "parameter": "temperature",
-            "value": temp,
-            "timestamp": timestamp,
-        },
-        {
-            "parameter": "humidity",
-            "value": humid,
-            "timestamp": timestamp,
-        },
-    ]
-    return data
-
-
 def record():
     config = get_config()
-    location_name = config["location"]["name"]
-    device_id = config["device"]["device_id"]
-    sensor_id = config["temperature"]["sensor_id"]
-    gpio_port = config["temperature"]["gpio_port"]
-    interval_seconds = int(config["temperature"]["interval_seconds"])
-    csv_columns = config["recording"]["csv_columns"].split(",")
-    timestamp_format = config["recording"]["timestamp_format"]
-    host = config["server"]["host"]
-    port = int(config["server"]["port"])
+    sensor = DHT22(int(config["temperature"]["gpio_port"]))
+    timestamp = datetime.now().strftime(
+        config["recording"]["timestamp_format"]
+    )
+
+    metadata = {
+        "device_id": config["device"]["device_id"],
+        "sensor_id": config["temperature"]["sensor_id"],
+        "location": config["location"]["name"],
+    }
 
     while True:
-        data = measure_temp_humid(gpio_port, timestamp_format)
-        for d in data:
-            d.update(
+        result = sensor.read_retry()
+        if result.ok:
+            data = [
                 {
-                    "device_id": device_id,
-                    "sensor_id": sensor_id,
-                    "location": location_name,
-                }
+                    "parameter": "temperature",
+                    "value": result.temperature,
+                    "timestamp": timestamp,
+                    **metadata,
+                },
+                {
+                    "parameter": "humidity",
+                    "value": result.humidity,
+                    "timestamp": timestamp,
+                    **metadata,
+                },
+            ]
+            send_data(
+                data=data,
+                host=config["server"]["host"],
+                port=int(config["server"]["port"]),
             )
-            send_data(data=d, host=host, port=port)
-            parameter = d.pop("parameter")
-            write_csv(
-                file_name=os.path.join(APP_DIR, f"{parameter}.csv"),
-                data=d,
-                column_names=csv_columns,
-            )
-        sleep(interval_seconds)
+            for d in data:
+                parameter = d.pop("parameter")
+                write_csv(
+                    file_name=os.path.join(APP_DIR, f"{parameter}.csv"),
+                    data=d,
+                    column_names=config["recording"]["csv_columns"].split(","),
+                )
+        else:
+            logger.error(f"Sensor reading error: {result.error.name}")
+
+        time.sleep(int(config["temperature"]["interval_seconds"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When upgrading the OS to bookworm and Python to 3.11, the DHT22 sensor code is not working anymore. The Adafruit Python library is deprecated and does not work, but the lower-level RPi.GPIO library still works. I add a module that reads DHT22 data and refactor the client bootstrap script.